### PR TITLE
Load after notification_center

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -31,7 +31,7 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
     {
         return [
             BundleConfig::create(RichardhjContaoEmailTokenLoginBundle::class)
-                ->setLoadAfter([ContaoCoreBundle::class]),
+                ->setLoadAfter([ContaoCoreBundle::class, 'notification_center']),
         ];
     }
 


### PR DESCRIPTION
Due to 

https://github.com/richardhj/contao-email-token-login/blob/b36302db38d58e84498aa354acfe8c4d8652afd1/src/Resources/contao/config/config.php#L13-L32

the following error can appear currently:

```
ErrorException:
Warning: Undefined global variable $NOTIFICATION_CENTER

  at vendor/richardhj/contao-email-token-login/src/Resources/contao/config/config.php:14
  at include('vendor/richardhj/contao-email-token-login/src/Resources/contao/config/config.php')
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Config.php:198)
```

This is because this bundle might be loaded before the `notification_center` due to the missing `setLoadAfter` definition. This PR fixes that.